### PR TITLE
feat: add admin-birthday command

### DIFF
--- a/src/commands/Birthday/admin-birthday.ts
+++ b/src/commands/Birthday/admin-birthday.ts
@@ -1,0 +1,116 @@
+import { BirthdayySubcommand } from '#lib/structures';
+import { PermissionLevels } from '#lib/types';
+import { UserCommand as BirthdayCommand } from '#root/commands/Birthday/birthday';
+import { getDateFromInteraction } from '#utils/common';
+import { interactionSuccess } from '#utils/embed';
+import { getBirthdays } from '#utils/functions';
+import { ApplyOptions } from '@sapphire/decorators';
+import { ApplicationCommandRegistry, CommandOptionsRunTypeEnum } from '@sapphire/framework';
+import { applyDescriptionLocalizedBuilder, resolveKey } from '@sapphire/plugin-i18next';
+import { isNullish, objectValues } from '@sapphire/utilities';
+import type { ChatInputCommandInteraction, SlashCommandBuilder, SlashCommandSubcommandBuilder } from 'discord.js';
+
+@ApplyOptions<BirthdayySubcommand.Options>({
+	subcommands: [
+		{ name: 'set', chatInputRun: 'chatInputRunSet' },
+		{ name: 'remove', chatInputRun: 'chatInputRunRemove' },
+		{ name: 'test', chatInputRun: 'chatInputRunTest' }
+	],
+	runIn: CommandOptionsRunTypeEnum.GuildAny,
+	permissionLevel: PermissionLevels.Moderator
+})
+export class UserCommand extends BirthdayySubcommand {
+	public override registerApplicationCommands(registry: ApplicationCommandRegistry) {
+		registry.registerChatInputCommand((builder) =>
+			this.registerSubcommands(
+				applyDescriptionLocalizedBuilder(builder, 'commands/admin-birthday:rootDescription') //
+					.setName('birthday')
+					.setDMPermission(false)
+			)
+		);
+	}
+
+	public async chatInputRunSet(interaction: ChatInputCommandInteraction<'cached'>) {
+		const user = interaction.options.getUser('user', true);
+		const birthday = getDateFromInteraction(interaction);
+
+		const result = await getBirthdays(interaction.guildId).upsert({ userId: user.id, birthday });
+
+		if (isNullish(result)) {
+			const content = await resolveKey(interaction, 'commands/admin-birthday:setFailure', { user });
+			return interaction.reply({ content });
+		}
+
+		const content = await resolveKey(interaction, 'commands/admin-birthday:setSuccess', { user, birthday });
+		return interaction.reply({ content });
+	}
+
+	public async chatInputRunRemove(interaction: ChatInputCommandInteraction<'cached'>) {
+		const user = interaction.options.getUser('user', true);
+		const result = await getBirthdays(interaction.guildId).remove(user.id);
+
+		if (isNullish(result)) {
+			const content = await resolveKey(interaction, 'commands/admin-birthday:removeFailureNoBirthday', { user });
+			return interaction.reply({ content });
+		}
+
+		const content = await resolveKey(interaction, 'commands/admin-birthday:removeSuccess', { user });
+		return interaction.reply({ content });
+	}
+
+	public async chatInputRunTest(interaction: ChatInputCommandInteraction<'cached'>) {
+		const user = interaction.options.getUser('user') ?? interaction.user;
+		const birthday = await getBirthdays(interaction.guild).fetch(user.id);
+
+		if (isNullish(birthday)) {
+			const content = await resolveKey(interaction, 'commands/admin-birthday:testFailure', { user });
+			return interaction.reply({ content });
+		}
+
+		const result = await getBirthdays(interaction.guild).announcedBirthday(birthday);
+
+		const content = result ? objectValues(result).join('\n') : 'Birthday Test Run';
+
+		return interaction.reply(interactionSuccess(content));
+	}
+
+	private registerSubcommands(builder: SlashCommandBuilder) {
+		return builder
+			.addSubcommand((subcommand) => this.registerSetSubCommand(subcommand))
+			.addSubcommand((subcommand) => this.registerRemoveSubCommand(subcommand))
+			.addSubcommand((subcommand) => this.registerTestSubCommand(subcommand));
+	}
+
+	private registerSetSubCommand(builder: SlashCommandSubcommandBuilder) {
+		return applyDescriptionLocalizedBuilder(builder, 'commands/admin-birthday:setDescription')
+			.setName('set')
+			.addIntegerOption((option) =>
+				BirthdayCommand.dayOptions(option, 'commands/admin-birthday:setOptionsDayDescription')
+			)
+			.addIntegerOption((option) =>
+				BirthdayCommand.monthOptions(option, 'commands/admin-birthday:setOptionsMonthDescription')
+			)
+			.addIntegerOption((option) =>
+				BirthdayCommand.yearOptions(option, 'commands/admin-birthday:setOptionsYearDescription')
+			)
+			.addUserOption((option) =>
+				BirthdayCommand.userOptions(option, 'commands/admin-birthday:setOptionsUserDescription')
+			);
+	}
+
+	private registerRemoveSubCommand(builder: SlashCommandSubcommandBuilder) {
+		return applyDescriptionLocalizedBuilder(builder, 'commands/birthday:removeDescription')
+			.setName('remove')
+			.addUserOption((option) =>
+				BirthdayCommand.userOptions(option, 'commands/admin-birthday:removeOptionsUserDescription')
+			);
+	}
+
+	private registerTestSubCommand(builder: SlashCommandSubcommandBuilder) {
+		return applyDescriptionLocalizedBuilder(builder, 'commands/birthday:testDescription')
+			.setName('test')
+			.addUserOption((option) =>
+				BirthdayCommand.userOptions(option, 'commands/admin-birthday:testOptionsUserDescription')
+			);
+	}
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,7 +81,7 @@ function parseInternationalizationDefaultVariablesPermissions() {
 function parseInternationalizationDefaultVariablesEmojis() {
 	return {
 		SUCCESS: Emojis.Success,
-		FAIL: Emojis.Fail,
+		FAILURE: Emojis.Fail,
 		PLUS: Emojis.Plus,
 		HEART: Emojis.Heart,
 		ARROW_LEFT: Emojis.ArrowLeft,
@@ -90,7 +90,7 @@ function parseInternationalizationDefaultVariablesEmojis() {
 		PEOPLE: Emojis.People,
 		ALARM: Emojis.Alarm,
 		CAKE: Emojis.Cake,
-		EXCLAMATION: Emojis.Exclamation
+		INFO: Emojis.Info
 	};
 }
 

--- a/src/languages/en-US/commands/admin-birthday.json
+++ b/src/languages/en-US/commands/admin-birthday.json
@@ -1,0 +1,17 @@
+{
+	"rootDescription": "Manage the birthday of a user.",
+	"setDescription": "Set the birthday of a user.",
+	"setOptionsDayDescription": "The day of the birthday.",
+	"setOptionsMonthDescription": "The month of the birthday.",
+	"setOptionsYearDescription": "The year of the birthday.",
+	"setOptionsUserDescription": "The user to set the birthday for.",
+	"setSuccess": "Successfully set the birthday of {{ user }} to {{ birthday }}.",
+	"setFailure": "Failed to set the birthday of {{ user }}.",
+	"removeDescription": "Remove the birthday of a user.",
+	"removeOptionsUserDescription": "The user to remove the birthday for.",
+	"removeSuccess": "Successfully removed the birthday of {{ user }}.",
+	"removeFailureNoBirthday": "{{ user }} does not have a birthday set.",
+	"testDescription": "Test the birthday of a user.",
+	"testOptionsUserDescription": "The user to test the birthday for.",
+	"testFailure": "Failed to test the birthday of {{ user }}."
+}

--- a/src/languages/en-US/commands/birthday.json
+++ b/src/languages/en-US/commands/birthday.json
@@ -1,72 +1,22 @@
 {
-    "birthdayName": "birthday",
-    "birthdayDescription": "Birthday Management Commands",
-    "setName": "set",
-    "setDescription": "Set your birthday date on the server.",
-    "set": {
-        "dayName": "day",
-        "dayDescription": "What day were you born?",
-        "monthName": "month",
-        "monthDescription": "What is your birthday month?",
-        "yearName": "year",
-        "yearDescription": "Which year are you born ?",
-        "userName": "user",
-        "userDescription": "Which user do you want to set the date of birth for? - MANAGER ONLY.",
-        "success": "Your birthday has been set to {{birthday}} on this server.",
-        "success_target": "{{target}}'s birthday was set to {{birthday}} on this server",
-        "hasNotPermissionManagesRoles": "You are not allowed to manage other users birthdays.",
-        "roleHigher": "You cannot execute this command on someone with a higher role than you!",
-        "error": "An error occurred while trying to set the birthday."
-    },
-    "listName": "list",
-    "listDescription": "List all registered birthdays",
-    "list": {
-        "embedList": {
-            "title": "Upcoming birthdays on the server!",
-            "thumbnail": {
-                "url": "https://media.discordapp.net/attachments/931273194160160829/931273371889586226/cake.png"
-            },
-            "footer": {
-                "text": "Manage your Birthday with /birthday set|remove"
-            }
-        },
-        "title": {
-            "month": "Birthdays in {{month}}",
-            "month_empty": "There are no birthdays for this month ({{month}}).",
-            "next": "Here is the list of the next 10 birthdays:",
-            "next_empty": "There are no birthdays on this server."
-        },
-        "monthName": "month",
-        "monthDescription": "Which month do you want the birthday list for?",
-        "format": "{{arrow}} {{user, userMention}} - {{date}} {{age}}"
-    },
-    "removeName": "remove",
-    "removeDescription": "Remove your birthday",
-    "remove": {
-        "userName": "user",
-        "userDescription": "Remove a Birthday for a Person - MANAGER ONLY",
-        "success": "Your birthday was successfully removed.",
-        "success_target": "{target}}'s birthday was successfully removed.",
-        "notRegistered": "Your birthday is not recorded. Use {{command}} to save it.",
-        "notRegistered_target": "{{target}}'s birthday is not yet registered.",
-        "hasNotPermissionManagesRoles": "You do not have permission to delete birthdays",
-        "target": "You do not have permission to delete this user's birthday."
-    },
-    "showName": "show",
-    "showDescription": "Show your birthday",
-    "show": {
-        "userName": "user",
-        "userDescription": "Show this user's birthday - MANAGER ONLY",
-        "title": "{{emoji}} Birthday",
-        "success": "{{emoji}} Your birthday is at the {{date}}.",
-        "success_target": "{{emoji}} {{target}}'s birthday is at the {{date}}.",
-        "notRegistered": "Your birthday is not registered. Use {{command}} to set it.",
-        "notRegistered_target": "{{target}}'s birthday is not registered."
-    },
-    "testName": "test",
-    "testDescription": "Test your current birthday setup",
-    "test": {
-        "userName": "user",
-        "userDescription": "Test this user's birthday - MANAGER ONLY"
-    }
+    "rootDescription": "Manage your birthday.",
+    "setDescription": "Set your birthday.",
+    "setOptionsDayDescription": "The day of the birthday.",
+    "setOptionsMonthDescription": "The month of the birthday.",
+    "setOptionsYearDescription": "The year of the birthday.",
+    "setSuccess": "Successfully set your birthday to {{ birthday }}.",
+    "setFailure": "{{FAILURE}} Failed to set your birthday",
+    "removeDescription": "Remove your birthday.",
+    "removeSuccess": "{{SUCCESS}} Successfully removed your birthday.",
+	"removeFailure": "💡 You do not have a birthday set.",
+	"listDescription": "List birthdays.",
+	"listOptionsMonthDescription": "The month to list birthdays for.",
+    "listTitle": "Birthdays for {{ month }}:",
+    "listTitleEmpty": "No birthdays found for {{ month }}.",
+	"showDescription": "Show your birthday.",
+	"showOptionsUserDescription": "The user to show the birthday for.",
+	"showNoBirthday": "💡 {{ user }} does not have a birthday set.",
+	"showSelfNoBirthday": "💡 You do not have a birthday set.",
+	"showSelf": "{{SUCCESS}} Your birthday is {{ birthday }}.",
+	"showBirthday": "{{ user }}'s birthday is {{ birthday }}."
 }

--- a/src/languages/fr/commands/admin-birthday.json
+++ b/src/languages/fr/commands/admin-birthday.json
@@ -1,0 +1,13 @@
+{
+	"rootDescription": "Gérer l'anniversaire d'un utilisateur.",
+	"setOptionsDayDescription": "Le jour de l'anniversaire.",
+	"setOptionsMonthDescription": "Le mois de l'anniversaire.",
+	"setOptionsYearDescription": "L'année de l'anniversaire.",
+	"setOptionsUserDescription": "L'utilisateur pour lequel définir l'anniversaire.",
+	"setSuccess": "L'anniversaire de {{ user }} a été défini avec succès au {{ birthday }}.",
+	"setFailure": "Échec de la définition de l'anniversaire de {{ user }}.",
+	"removeOptionsUserDescription": "L'utilisateur pour lequel supprimer l'anniversaire.",
+	"removeSuccess": "L'anniversaire de {{ user }} a été supprimé avec succès.",
+	"removeFailureNoBirthday": "{{ user }} n'a pas d'anniversaire défini.",
+	"testFailure": "Échec de la vérification de l'anniversaire de {{ user }}."
+}

--- a/src/languages/fr/commands/birthday.json
+++ b/src/languages/fr/commands/birthday.json
@@ -1,54 +1,22 @@
 {
-    "birthdayName": "anniversaire",
-    "birthdayDescription": "Commandes de gestion d’anniversaire",
-    "setName": "definir",
-    "setDescription": "Définir votre date d'anniversaire sur le serveur.",
-    "set": {
-        "dayName": "jour",
-        "dayDescription": "Quel jour es-tu née ?",
-        "monthName": "mois",
-        "monthDescription": "Quel est votre mois d'anniversaire ?",
-        "yearName": "année",
-        "yearDescription": "En quelle année es-tu né ?",
-        "userName": "utilisateur",
-        "userDescription": "De quel utilisateur veux-tu définir la date de naissance ? - MANAGER ONLY.",
-        "success": "Votre anniversaire a bien été défini au {{birthday}} sur ce serveur.",
-        "success_target": "L'anniversaire de {{target}} a bien été défini au {{birthday}} sur ce serveur",
-        "hasNotPermissionManagesRoles": "Tu n'est pas autorisé à gérer les anniversaires d'autres utilisateurs.",
-        "roleHigher": "You cannot execute this command on someone with a higher role than you!"
-    },
-    "listName": "liste",
-    "listDescription": "Lister tous les anniversaires enregistrés",
-    "list": {
-        "embedTitle": ""
-    },
-    "removeName": "retirer",
-    "removeDescription": "Supprimer votre anniversaire",
-    "remove": {
-        "userName": "user",
-        "userDescription": "Supprimer l'anniversaire pour cette utilisateur - MANAGER ONLY",
-        "success": "Votre anniversaire a été supprimé avec succès.",
-        "success_target": "L'anniversaire de {{target}} à bien été supprimé.",
-        "notRegistered": "Votre anniversaire n'est pas enregistré. Utilisez {{command}} pour l'enregistrer.",
-        "notRegistered_target": "L'anniversaire de {{target}} n'est pas enregistré.",
-        "hasNotPermissionManagesRoles": "Vous n'avez pas la permission de supprimer des anniversaires",
-        "target": "Vous n'êtes pas autorisé à supprimer l'anniversaire de cet utilisateur."
-    },
-    "showName": "montrer",
-    "showDescription": "Montrer votre anniversaire",
-    "show": {
-        "userName": "utilisateur",
-        "userDescription": "Montrer l'anniversaire de cette utilisateur - MANAGER ONLY",
-        "title": "{{emoji}} Anniversaire",
-        "success": "{{emoji}} Votre anniversaire est défini sûr {{date}}.",
-        "success_target": "{{emoji}} L'anniversaire de {{target}} est défini sûr {{date}}.",
-        "notRegistered": "Votre anniversaire n'est pas enregistré. \nUtilisez {{command}} pour l'enregistrer.",
-        "notRegistered_target": "L'anniversaire de {{target}} n'est pas enregistré."
-    },
-    "testName": "test",
-    "testDescription": "Testez votre configuration d’anniversaire actuelle",
-    "test": {
-        "userName": "utilisateur",
-        "userDescription": "Tester l'anniversaire de cet utilisateur - MANAGER ONLY"
-    }
+    "rootDescription": "Gérer votre anniversaire.",
+    "setDescription": "Définir votre anniversaire.",
+    "setOptionsDayDescription": "Le jour de l'anniversaire.",
+    "setOptionsMonthDescription": "Le mois de l'anniversaire.",
+    "setOptionsYearDescription": "L'année de l'anniversaire.",
+    "setSuccess": "Votre anniversaire a été défini avec succès à {{ birthday }}.",
+    "setFailure": "{{FAILURE}} Échec de la définition de votre anniversaire",
+    "removeDescription": "Supprimer votre anniversaire.",
+    "removeSuccess": "{{SUCCESS}} Votre anniversaire a été supprimé avec succès.",
+	"removeFailure": "💡 Vous n'avez pas d'anniversaire défini.",
+	"listDescription": "Lister les anniversaires.",
+	"listOptionsMonthDescription": "Le mois pour lister les anniversaires.",
+    "listTitle": "Anniversaires de {{ month }}:",
+    "listTitleEmpty": "Aucun anniversaire trouvé pour {{ month }}.",
+	"showDescription": "Afficher votre anniversaire.",
+	"showOptionsUserDescription": "L'utilisateur pour afficher l'anniversaire.",
+	"showNoBirthday": "💡 {{ user }} n'a pas d'anniversaire défini.",
+	"showSelfNoBirthday": "💡 Vous n'avez pas d'anniversaire défini.",
+	"showSelf": "{{SUCCESS}} Votre anniversaire est le {{ birthday }}.",
+	"showBirthday": "L'anniversaire de {{ user }} est le {{ birthday }}."
 }

--- a/src/lib/util/constants.ts
+++ b/src/lib/util/constants.ts
@@ -19,7 +19,7 @@ export enum Emojis {
 	ArrowLeft = '<:arrow_left_birthdayy:1102221941223477268>',
 	Plus = '<:plus_birthdayy:1102222100544110712>',
 	Link = '<:link_birthdayy:1102222076380725319>',
-	Exclamation = '<:exclamation_mark_birthdayy:1102222058777223209>',
+	Info = '<:exclamation_mark_birthdayy:1102222058777223209>',
 	Cake = '<:cake_birthdayy:1102221988380020766>',
 	Crown = '<:crown_birthdayy:1102222034458660915>',
 	News = '<:news_birthdayy:1102222080029761618>',

--- a/src/routes/webhook/topgg.ts
+++ b/src/routes/webhook/topgg.ts
@@ -81,7 +81,7 @@ export class UserRoute extends Route {
 
 	private async sendVoteNotification(user: User) {
 		const embed = new DefaultEmbedBuilder()
-			.setTitle(`${Emojis.Exclamation} New Vote on TopGG!`)
+			.setTitle(`${Emojis.Info} New Vote on TopGG!`)
 			.setDescription(
 				`\`${user.username}#${user.discriminator}\` has **voted** for ${container.client.user!.displayName}! Use \`/vote\` or vote [here](https://top.gg/bot/${container.client.id}/vote) directly.`
 			)


### PR DESCRIPTION
This pull request adds a new command called "admin-birthday" that allows admins to manage the birthday of a user. The command includes options to set, remove, and test birthdays. Additionally, the pull request includes updates to emoji names and translations for internationalization.