### PR TITLE
fix: update actions/setup-node and actions/cache versions in CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Setup node env 🏗
-        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+        uses: actions/setup-node@v6.1.0
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
@@ -26,7 +26,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Cache node_modules 📦
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@v5
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
This pull request updates dependencies used in the GitHub Actions workflow to newer versions, improving maintainability and ensuring compatibility with the latest features and security patches.

**GitHub Actions dependency updates:**

* Updated `actions/setup-node` from a specific commit of v3.7.0 to the latest v6.1.0 in `.github/workflows/continuous-integration.yml`
* Updated `actions/cache` from a specific commit of v3.3.1 to the latest v5 in `.github/workflows/continuous-integration.yml`