### PR TITLE
fix: add job cleanup configuration constants for Bull options

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,12 @@ function parseInternationalizationOptions(): InternationalizationOptions {
 	};
 }
 
+// Job cleanup configuration constants
+const COMPLETED_JOB_AGE_SECONDS = 3600; // 1 hour
+const COMPLETED_JOB_MAX_COUNT = 100;
+const FAILED_JOB_AGE_SECONDS = 86400; // 1 day
+const FAILED_JOB_MAX_COUNT = 50;
+
 function parseBullOptions(): QueueOptions {
 	return {
 		connection: {
@@ -69,6 +75,10 @@ function parseBullOptions(): QueueOptions {
 			host: envParseString('REDIS_HOST'),
 			db: envParseNumber('REDIS_DB'),
 			username: envParseString('REDIS_USERNAME'),
+		},
+		defaultJobOptions: {
+			removeOnComplete: { age: COMPLETED_JOB_AGE_SECONDS, count: COMPLETED_JOB_MAX_COUNT },
+			removeOnFail: { age: FAILED_JOB_AGE_SECONDS, count: FAILED_JOB_MAX_COUNT },
 		},
 	};
 }


### PR DESCRIPTION
This pull request introduces job cleanup configuration to the Bull queue setup, ensuring that completed and failed jobs are automatically removed after a certain age or count threshold. This helps manage Redis storage and maintain queue performance.

Job cleanup configuration:

* Added constants in `src/config.ts` to define maximum age and count for completed and failed jobs (`COMPLETED_JOB_AGE_SECONDS`, `COMPLETED_JOB_MAX_COUNT`, `FAILED_JOB_AGE_SECONDS`, `FAILED_JOB_MAX_COUNT`).
* Updated the `parseBullOptions` function in `src/config.ts` to set `defaultJobOptions` for automatic removal of completed and failed jobs using the defined constants.